### PR TITLE
Refer to "Parso library update"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ scalacOptions ++= Seq("-target:jvm-1.7" )
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 libraryDependencies ++= Seq(
-  "com.ggasoftware" % "parso" % "1.2.1",
+//  "com.ggasoftware" % "parso" % "1.2.1",
+  "com.epam" % "parso" % "2.0.1",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "org.apache.logging.log4j" %% "log4j-api-scala" % "2.7"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ test in assembly := {}
 
 //override modified parser class
 assemblyMergeStrategy in assembly := {
-  case PathList("com", "ggasoftware", xs @ _*)         => MergeStrategy.first
+  case PathList("com", "epam", xs @ _*)         => MergeStrategy.first
   case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.saurfang</groupId>
+    <artifactId>spark-sas7bdat_2.11</artifactId>
+    <packaging>jar</packaging>
+    <description>spark-sas7bdat</description>
+    <version>1.1.5</version>
+    <licenses>
+        <license>
+            <name>GPL-3.0</name>
+            <url>http://opensource.org/licenses/GPL-3.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <name>spark-sas7bdat</name>
+    <organization>
+        <name>com.github.saurfang</name>
+    </organization>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.11.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.11</artifactId>
+            <version>2.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.epam</groupId>
+            <artifactId>parso</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+            <version>2.2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api-scala_2.11</artifactId>
+            <version>2.7</version>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>SparkPackagesRepo</id>
+            <name>Spark Packages Repo</name>
+            <url>https://dl.bintray.com/spark-packages/maven/</url>
+            <layout>default</layout>
+        </repository>
+    </repositories>
+</project>

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -15,8 +15,10 @@
  * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  ***************************************************************************/
 
-package com.ggasoftware.parso;
+package com.epam.parso.impl;
 
+import com.epam.parso.Column;
+import com.epam.parso.SasFileProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
 
-import static com.ggasoftware.parso.SasFileConstants.*;
+import static com.epam.parso.impl.SasFileConstants.*;
 
 /**
  * This is a class that parses sas7bdat files. When parsing a sas7bdat file, to interact with the library,

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -211,11 +211,18 @@ public class SasFileParser {
         subheaderIndexToClass = Collections.unmodifiableMap(tmpMap);
     }
 
-    public static class SasFileConstants implements com.epam.parso.impl.SasFileConstants {
+    public static class SasFileConstants {
         /**
          * The page type storing only metadata as a set of subheaders.
          */
         public static final int PAGE_META_TYPE = 0;
+
+        public static final List<String> DATE_TIME_FORMAT_STRINGS = com.epam.parso.impl.SasFileConstants.DATE_TIME_FORMAT_STRINGS;
+
+        public static final List<String> DATE_FORMAT_STRINGS = com.epam.parso.impl.SasFileConstants.DATE_FORMAT_STRINGS;
+
+        public static double EPSILON = com.epam.parso.impl.SasFileConstants.EPSILON;
+
     }
 
     /**

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -221,7 +221,7 @@ public class SasFileParser {
     /**
      * SasFileParser builder class made using builder pattern.
      */
-    public static class Builder {
+    public static class ExternalBuilder {
         /**
          * Builder variable for {@link SasFileParser#sasFileStream} variable.
          */
@@ -242,7 +242,7 @@ public class SasFileParser {
          * @param val value to be set.
          * @return result builder.
          */
-        public Builder sasFileStream(InputStream val) {
+        public ExternalBuilder sasFileStream(InputStream val) {
             sasFileStream = val;
             return this;
         }
@@ -252,7 +252,7 @@ public class SasFileParser {
          * @param val value to be set.
          * @return result builder.
          */
-        public Builder encoding(String val) {
+        public ExternalBuilder encoding(String val) {
             encoding = val;
             return this;
         }
@@ -262,7 +262,7 @@ public class SasFileParser {
          * @param val value to be set.
          * @return result builder.
          */
-        public Builder byteOutput(Boolean val) {
+        public ExternalBuilder byteOutput(Boolean val) {
             byteOutput = val;
             return this;
         }
@@ -281,7 +281,7 @@ public class SasFileParser {
      *
      * @param builder the container with properties information.
      */
-    SasFileParser(Builder builder) {
+    SasFileParser(ExternalBuilder builder) {
         sasFileStream = new DataInputStream(builder.sasFileStream);
         encoding = builder.encoding;
         byteOutput = builder.byteOutput;

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -19,6 +19,7 @@ package com.epam.parso.impl;
 
 import com.epam.parso.Column;
 import com.epam.parso.SasFileProperties;
+import com.epam.parso.SasFileReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +107,7 @@ public class SasFileParser {
     /**
      * The variable to store all the properties from the sas7bdat file.
      */
-    private SasFileProperties sasFileProperties = new SasFileProperties.Builder().build();
+    private SasFileProperties sasFileProperties = new SasFileProperties();
 
     /**
      * The list of text blocks with information about file compression and table columns (name, label, format).
@@ -185,8 +186,8 @@ public class SasFileParser {
     private Map<String, Decompressor> literalsToDecompressor = new HashMap<String, Decompressor>();
 
     {
-        literalsToDecompressor.put(COMPRESS_CHAR_IDENTIFYING_STRING, CharDecompressor.instance);
-        literalsToDecompressor.put(COMPRESS_BIN_IDENTIFYING_STRING, BinDecompressor.instance);
+        literalsToDecompressor.put(COMPRESS_CHAR_IDENTIFYING_STRING, CharDecompressor.INSTANCE);
+        literalsToDecompressor.put(COMPRESS_BIN_IDENTIFYING_STRING, BinDecompressor.INSTANCE);
     }
 
     /**

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -211,6 +211,13 @@ public class SasFileParser {
         subheaderIndexToClass = Collections.unmodifiableMap(tmpMap);
     }
 
+    public static class SasFileConstants implements com.epam.parso.impl.SasFileConstants {
+        /**
+         * The page type storing only metadata as a set of subheaders.
+         */
+        public static final int PAGE_META_TYPE = 0;
+    }
+
     /**
      * SasFileParser builder class made using builder pattern.
      */

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -59,8 +59,8 @@ public class SasFileParser {
     private byte[] cachedPage = null;
 
     /**
-     * The type of the current page when reading the file. If it is other than {@link SasFileConstants#PAGE_META_TYPE},
-     * {@link SasFileConstants#PAGE_MIX_TYPE} and {@link SasFileConstants#PAGE_DATA_TYPE} page is skipped.
+     * The type of the current page when reading the file. If it is other than {@link com.epam.parso.impl.SasFileConstants#PAGE_META_TYPE},
+     * {@link com.epam.parso.impl.SasFileConstants#PAGE_MIX_TYPE} and {@link com.epam.parso.impl.SasFileConstants#PAGE_DATA_TYPE} page is skipped.
      */
     private int currentPageType;
 
@@ -152,7 +152,7 @@ public class SasFileParser {
 
     /**
      * The mapping of subheader signatures to the corresponding elements in {@link SasFileParser.SUBHEADER_INDEXES}.
-     * Depending on the value at the {@link SasFileConstants#ALIGN_2_OFFSET} offset, signatures take 4 bytes
+     * Depending on the value at the {@link com.epam.parso.impl.SasFileConstants#ALIGN_2_OFFSET} offset, signatures take 4 bytes
      * for 32-bit version sas7bdat files and 8 bytes for the 64-bit version files.
      */
     private static final Map<Long, SUBHEADER_INDEXES> SUBHEADER_SIGNATURE_TO_INDEX;
@@ -302,8 +302,8 @@ public class SasFileParser {
 
     /**
      * The class to store subheaders pointers that contain information about the offset, length, type
-     * and compression of subheaders (see {@link SasFileConstants#TRUNCATED_SUBHEADER_ID},
-     * {@link SasFileConstants#COMPRESSED_SUBHEADER_ID}, {@link SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
+     * and compression of subheaders (see {@link com.epam.parso.impl.SasFileConstants#TRUNCATED_SUBHEADER_ID},
+     * {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_ID}, {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
      * for details).
      */
     private class SubheaderPointer {
@@ -318,15 +318,15 @@ public class SasFileParser {
         private long length;
 
         /**
-         * The type of subheader compression. If the type is {@link SasFileConstants#TRUNCATED_SUBHEADER_ID}
+         * The type of subheader compression. If the type is {@link com.epam.parso.impl.SasFileConstants#TRUNCATED_SUBHEADER_ID}
          * the subheader does not contain information relevant to the current issues. If the type is
-         * {@link SasFileConstants#COMPRESSED_SUBHEADER_ID} the subheader can be compressed
+         * {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_ID} the subheader can be compressed
          * (depends on {@link SubheaderPointer#type}).
          */
         private byte compression;
 
         /**
-         * The subheader type. If the type is {@link SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
+         * The subheader type. If the type is {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
          * the subheader is compressed. Otherwise, there is no compression.
          */
         private byte type;
@@ -337,10 +337,10 @@ public class SasFileParser {
          * @param offset      the offset of the subheader from the beginning of the page.
          * @param length      the subheader length.
          * @param compression the subheader compression type. If the type is
-         *                    {@link SasFileConstants#TRUNCATED_SUBHEADER_ID}, the subheader does not contain useful
-         *                    information. If the type is {@link SasFileConstants#COMPRESSED_SUBHEADER_ID},
+         *                    {@link com.epam.parso.impl.SasFileConstants#TRUNCATED_SUBHEADER_ID}, the subheader does not contain useful
+         *                    information. If the type is {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_ID},
          *                    the subheader can be compressed (depends on {@link SubheaderPointer#type}).
-         * @param type        the subheader type. If the type is {@link SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
+         * @param type        the subheader type. If the type is {@link com.epam.parso.impl.SasFileConstants#COMPRESSED_SUBHEADER_TYPE}
          *                    the subheader is compressed, otherwise, it is not.
          */
         SubheaderPointer(long offset, long length, byte compression, byte type) {
@@ -381,7 +381,7 @@ public class SasFileParser {
     /**
      * The method to read and parse metadata from the sas7bdat file`s header in {@link SasFileParser#sasFileProperties}.
      * After reading is complete, {@link SasFileParser#currentFilePosition} is set to the end of the header whose length
-     * is stored at the {@link SasFileConstants#HEADER_SIZE_OFFSET} offset.
+     * is stored at the {@link com.epam.parso.impl.SasFileConstants#HEADER_SIZE_OFFSET} offset.
      *
      * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
      */
@@ -438,9 +438,9 @@ public class SasFileParser {
 
     /**
      * The method to read pages of the sas7bdat file. First, the method reads the page type
-     * (at the {@link SasFileConstants#PAGE_TYPE_OFFSET} offset), the number of rows on the page
-     * (at the {@link SasFileConstants#BLOCK_COUNT_OFFSET} offset), and the number of subheaders
-     * (at the {@link SasFileConstants#SUBHEADER_COUNT_OFFSET} offset). Then, depending on the page type,
+     * (at the {@link com.epam.parso.impl.SasFileConstants#PAGE_TYPE_OFFSET} offset), the number of rows on the page
+     * (at the {@link com.epam.parso.impl.SasFileConstants#BLOCK_COUNT_OFFSET} offset), and the number of subheaders
+     * (at the {@link com.epam.parso.impl.SasFileConstants#SUBHEADER_COUNT_OFFSET} offset). Then, depending on the page type,
      * the method calls the function to process the page.
      *
      * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
@@ -458,7 +458,7 @@ public class SasFileParser {
 
     /**
      * The method to parse and read metadata of a page, used for pages of the {@link SasFileConstants#PAGE_META_TYPE}
-     * and {@link SasFileConstants#PAGE_MIX_TYPE} types. The method goes through subheaders, one by one, and calls
+     * and {@link com.epam.parso.impl.SasFileConstants#PAGE_MIX_TYPE} types. The method goes through subheaders, one by one, and calls
      * the processing functions depending on their signatures.
      *
      * @param bitOffset         the offset from the beginning of the page at which the page stores its metadata.
@@ -561,7 +561,7 @@ public class SasFileParser {
     /**
      * The class to process subheaders of the RowSizeSubheader type that store information about the table rows length
      * (in bytes), the number of rows in the table and the number of rows on the last page of the
-     * {@link SasFileConstants#PAGE_MIX_TYPE} type. The results are stored in {@link SasFileProperties#rowLength},
+     * {@link com.epam.parso.impl.SasFileConstants#PAGE_MIX_TYPE} type. The results are stored in {@link SasFileProperties#rowLength},
      * {@link SasFileProperties#rowCount}, and {@link SasFileProperties#mixPageRowCount}, respectively.
      */
     private class RowSizeSubheader implements ProcessingSubheader {
@@ -925,8 +925,8 @@ public class SasFileParser {
     /**
      * The method to read next page from sas7bdat file and put it into {@link SasFileParser#cachedPage}. If this page
      * has {@link SasFileConstants#PAGE_META_TYPE} type method process it's subheaders. Method skips page with type
-     * other than {@link SasFileConstants#PAGE_META_TYPE}, {@link SasFileConstants#PAGE_MIX_TYPE} or
-     * {@link SasFileConstants#PAGE_DATA_TYPE} and reads next.
+     * other than {@link SasFileConstants#PAGE_META_TYPE}, {@link com.epam.parso.impl.SasFileConstants#PAGE_MIX_TYPE} or
+     * {@link com.epam.parso.impl.SasFileConstants#PAGE_DATA_TYPE} and reads next.
      * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
      */
     void readNextPage() throws IOException {
@@ -1186,7 +1186,7 @@ public class SasFileParser {
 
     /**
      * The function to convert a bytes array into a number (int or long depending on the value located at
-     * the {@link SasFileConstants#ALIGN_2_OFFSET} offset).
+     * the {@link com.epam.parso.impl.SasFileConstants#ALIGN_2_OFFSET} offset).
      *
      * @param byteBuffer the long value represented by a bytes array.
      * @return a long value. If the number was stored as int, then after conversion it is converted to long
@@ -1203,12 +1203,12 @@ public class SasFileParser {
     /**
      * The function to convert an array of bytes with any order of bytes into {@link ByteBuffer}.
      * {@link ByteBuffer} has the order of bytes defined in the file located at the
-     * {@link SasFileConstants#ALIGN_2_OFFSET} offset.
+     * {@link com.epam.parso.impl.SasFileConstants#ALIGN_2_OFFSET} offset.
      * Later the parser converts result {@link ByteBuffer} into a number.
      *
      * @param data the input array of bytes with the little-endian or big-endian order.
      * @return {@link ByteBuffer} with the order of bytes defined in the file located at
-     *         the {@link SasFileConstants#ALIGN_2_OFFSET} offset.
+     *         the {@link com.epam.parso.impl.SasFileConstants#ALIGN_2_OFFSET} offset.
      */
     private ByteBuffer byteArrayToByteBuffer(byte[] data) {
         ByteBuffer byteBuffer = ByteBuffer.wrap(data);

--- a/src/main/java/com/epam/parso/impl/SasFileParserExternal.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParserExternal.java
@@ -34,8 +34,8 @@ import static com.epam.parso.impl.SasFileConstants.*;
  * This is a class that parses sas7bdat files. When parsing a sas7bdat file, to interact with the library,
  * do not use this class but use {@link SasFileReader} instead.
  */
-public class SasFileParser {
-    private static final Logger logger = LoggerFactory.getLogger(SasFileParser.class);
+public class SasFileParserExternal {
+    private static final Logger logger = LoggerFactory.getLogger(SasFileParserExternal.class);
 
     /**
      * The input stream through which the sas7bdat is read.
@@ -54,7 +54,7 @@ public class SasFileParser {
 
     /**
      * A cash to store the current page of the sas7bdat file. Used to avoid posing buffering requirements
-     * to {@link SasFileParser#sasFileStream}.
+     * to {@link SasFileParserExternal#sasFileStream}.
      */
     private byte[] cachedPage = null;
 
@@ -111,7 +111,7 @@ public class SasFileParser {
 
     /**
      * The list of text blocks with information about file compression and table columns (name, label, format).
-     * Every element corresponds to a {@link SasFileParser.ColumnTextSubheader}. The first text block includes
+     * Every element corresponds to a {@link SasFileParserExternal.ColumnTextSubheader}. The first text block includes
      * the information about compression.
      */
     private List<String> columnsNamesStrings = new ArrayList<String>();
@@ -151,7 +151,7 @@ public class SasFileParser {
     }
 
     /**
-     * The mapping of subheader signatures to the corresponding elements in {@link SasFileParser.SUBHEADER_INDEXES}.
+     * The mapping of subheader signatures to the corresponding elements in {@link SasFileParserExternal.SUBHEADER_INDEXES}.
      * Depending on the value at the {@link com.epam.parso.impl.SasFileConstants#ALIGN_2_OFFSET} offset, signatures take 4 bytes
      * for 32-bit version sas7bdat files and 8 bytes for the 64-bit version files.
      */
@@ -191,7 +191,7 @@ public class SasFileParser {
     }
 
     /**
-     * The mapping between elements from {@link SasFileParser.SUBHEADER_INDEXES} and classes corresponding
+     * The mapping between elements from {@link SasFileParserExternal.SUBHEADER_INDEXES} and classes corresponding
      * to each subheader. This is necessary because defining the subheader type being processed is dynamic.
      * Every class has an overridden function that processes the related subheader type.
      */
@@ -226,21 +226,21 @@ public class SasFileParser {
     }
 
     /**
-     * SasFileParser builder class made using builder pattern.
+     * SasFileParserExternal builder class made using builder pattern.
      */
     public static class ExternalBuilder {
         /**
-         * Builder variable for {@link SasFileParser#sasFileStream} variable.
+         * Builder variable for {@link SasFileParserExternal#sasFileStream} variable.
          */
         private InputStream sasFileStream = null;
 
         /**
-         * Default value for {@link SasFileParser#encoding} variable.
+         * Default value for {@link SasFileParserExternal#encoding} variable.
          */
         private String encoding = "ASCII";
 
         /**
-         * Default value for {@link SasFileParser#byteOutput} variable.
+         * Default value for {@link SasFileParserExternal#byteOutput} variable.
          */
         private Boolean byteOutput = false;
 
@@ -275,20 +275,20 @@ public class SasFileParser {
         }
 
         /**
-         * The function to create variable of SasFileParser class using current builder.
+         * The function to create variable of SasFileParserExternal class using current builder.
          */
-        public SasFileParser build() {
-            return new SasFileParser(this);
+        public SasFileParserExternal build() {
+            return new SasFileParserExternal(this);
         }
     }
 
     /**
      * The constructor that reads metadata from the sas7bdat, parses it and puts the results in
-     * {@link SasFileParser#sasFileProperties}.
+     * {@link SasFileParserExternal#sasFileProperties}.
      *
      * @param builder the container with properties information.
      */
-    SasFileParser(ExternalBuilder builder) {
+    SasFileParserExternal(ExternalBuilder builder) {
         sasFileStream = new DataInputStream(builder.sasFileStream);
         encoding = builder.encoding;
         byteOutput = builder.byteOutput;
@@ -360,9 +360,9 @@ public class SasFileParser {
 
     /**
      * The method that reads and parses metadata from the sas7bdat and puts the results in
-     * {@link SasFileParser#sasFileProperties}.
+     * {@link SasFileParserExternal#sasFileProperties}.
      *
-     * @throws IOException - appears if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException - appears if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private void getMetadataFromSasFile() throws IOException {
         boolean endOfMetadata = false;
@@ -379,11 +379,11 @@ public class SasFileParser {
     }
 
     /**
-     * The method to read and parse metadata from the sas7bdat file`s header in {@link SasFileParser#sasFileProperties}.
-     * After reading is complete, {@link SasFileParser#currentFilePosition} is set to the end of the header whose length
+     * The method to read and parse metadata from the sas7bdat file`s header in {@link SasFileParserExternal#sasFileProperties}.
+     * After reading is complete, {@link SasFileParserExternal#currentFilePosition} is set to the end of the header whose length
      * is stored at the {@link com.epam.parso.impl.SasFileConstants#HEADER_SIZE_OFFSET} offset.
      *
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private void processSasFileHeader() throws IOException {
         int align1 = 0;
@@ -443,7 +443,7 @@ public class SasFileParser {
      * (at the {@link com.epam.parso.impl.SasFileConstants#SUBHEADER_COUNT_OFFSET} offset). Then, depending on the page type,
      * the method calls the function to process the page.
      *
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private boolean processSasFilePageMeta() throws IOException {
         int bitOffset = sasFileProperties.isU64() ? PAGE_BIT_OFFSET_X64 : PAGE_BIT_OFFSET_X86;
@@ -463,7 +463,7 @@ public class SasFileParser {
      *
      * @param bitOffset         the offset from the beginning of the page at which the page stores its metadata.
      * @param subheaderPointers the number of subheaders on the page.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} string is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} string is impossible.
      */
     private void processPageMetadata(int bitOffset, List<SubheaderPointer> subheaderPointers)
             throws IOException {
@@ -497,9 +497,9 @@ public class SasFileParser {
      * The function to read a subheader signature at the offset known from its ({@link SubheaderPointer}).
      *
      * @param subheaderPointerOffset the offset at which the subheader is located.
-     * @return - the subheader signature to search for in the {@link SasFileParser#SUBHEADER_SIGNATURE_TO_INDEX}
+     * @return - the subheader signature to search for in the {@link SasFileParserExternal#SUBHEADER_SIGNATURE_TO_INDEX}
      *           mapping later.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private long readSubheaderSignature(Long subheaderPointerOffset) throws IOException {
         int intOrLongLength = sasFileProperties.isU64() ? BYTES_IN_LONG : BYTES_IN_INT;
@@ -515,10 +515,10 @@ public class SasFileParser {
      * and {@link SubheaderPointer#type}.
      *
      * @param subheaderSignature the subheader signature to search for in the
-     *                           {@link SasFileParser#SUBHEADER_SIGNATURE_TO_INDEX} mapping
+     *                           {@link SasFileParserExternal#SUBHEADER_SIGNATURE_TO_INDEX} mapping
      * @param compression        the type of subheader compression ({@link SubheaderPointer#compression})
      * @param type               the subheader type ({@link SubheaderPointer#type})
-     * @return an element from the  {@link SasFileParser.SUBHEADER_INDEXES} enumeration that defines the type of
+     * @return an element from the  {@link SasFileParserExternal.SUBHEADER_INDEXES} enumeration that defines the type of
      *         the current subheader
      */
     private SUBHEADER_INDEXES chooseSubheaderClass(long subheaderSignature, int compression, int type) {
@@ -537,7 +537,7 @@ public class SasFileParser {
      * @param subheaderPointerOffset the offset before the list of {@link SubheaderPointer}.
      * @param subheaderPointerIndex  the index of the subheader pointer being read.
      * @return the subheader pointer.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private SubheaderPointer processSubheaderPointers(long subheaderPointerOffset, int subheaderPointerIndex)
             throws IOException {
@@ -572,7 +572,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -606,7 +606,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -630,7 +630,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -640,7 +640,7 @@ public class SasFileParser {
     /**
      * The class to process subheaders of the ColumnTextSubheader type that store information about
      * file compression and table columns (name, label, format). The first subheader of this type includes the file
-     * compression information. The results are stored in {@link SasFileParser#columnsNamesStrings} and
+     * compression information. The results are stored in {@link SasFileParserExternal#columnsNamesStrings} and
      * {@link SasFileProperties#compressionMethod}.
      */
     private class ColumnTextSubheader implements ProcessingSubheader {
@@ -650,7 +650,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -704,7 +704,7 @@ public class SasFileParser {
      * The class to process subheaders of the ColumnNameSubheader type that store information about the index of
      * corresponding subheader of the ColumnTextSubheader type whose text field stores the name of the column
      * corresponding to the current subheader. They also store the offset (in symbols) of the names from the beginning
-     * of the text field and the length of names (in symbols). The {@link SasFileParser#columnsNamesList} list stores
+     * of the text field and the length of names (in symbols). The {@link SasFileParserExternal#columnsNamesList} list stores
      * the resulting names.
      */
     private class ColumnNameSubheader implements ProcessingSubheader {
@@ -716,7 +716,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -747,8 +747,8 @@ public class SasFileParser {
      * The class to process subheaders of the ColumnAttributesSubheader type that store information about
      * the data length (in bytes) of the current column and about the offset (in bytes) of the current column`s data
      * from the beginning of the row with data. They also store the column`s data type: {@link Number} and
-     * {@link String}. The resulting names are stored in the {@link SasFileParser#columnsDataOffset},
-     * {@link SasFileParser#columnsDataLength}, and{@link SasFileParser#columnsTypesList}.
+     * {@link String}. The resulting names are stored in the {@link SasFileParserExternal#columnsDataOffset},
+     * {@link SasFileParserExternal#columnsDataLength}, and{@link SasFileParserExternal#columnsTypesList}.
      */
     private class ColumnAttributesSubheader implements ProcessingSubheader {
         /**
@@ -757,7 +757,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -788,7 +788,7 @@ public class SasFileParser {
      *   to the current subheader,
      * - offsets (in symbols) of the formats and labels from the beginning of the text field,
      * - lengths of the formats and labels (in symbols),
-     * The {@link SasFileParser#columns} list stores the results.
+     * The {@link SasFileParserExternal#columns} list stores the results.
      */
     private class FormatAndLabelSubheader implements ProcessingSubheader {
         /**
@@ -802,7 +802,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -848,7 +848,7 @@ public class SasFileParser {
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -861,12 +861,12 @@ public class SasFileParser {
     private class DataSubheader implements ProcessingSubheader {
         /**
          * The method to read compressed or uncompressed data from the subheader. The results are stored as a row
-         * in {@link SasFileParser#currentRow}. The {@link SasFileParser#processByteArrayWithData(long, long)} function
+         * in {@link SasFileParserExternal#currentRow}. The {@link SasFileParserExternal#processByteArrayWithData(long, long)} function
          * converts the array of bytes into a list of objects.
          *
          * @param subheaderOffset the offset at which the subheader is located.
          * @param subheaderLength the subheader length.
-         * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+         * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
          */
         @Override
         public void processSubheader(long subheaderOffset, long subheaderLength) throws IOException {
@@ -878,7 +878,7 @@ public class SasFileParser {
      * The function to read next row from current sas7bdat file.
      *
      * @return the object array containing elements of current row.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     Object[] readNext() throws IOException {
         int bitOffset = sasFileProperties.isU64() ? PAGE_BIT_OFFSET_X64 : PAGE_BIT_OFFSET_X86;
@@ -923,11 +923,11 @@ public class SasFileParser {
     }
 
     /**
-     * The method to read next page from sas7bdat file and put it into {@link SasFileParser#cachedPage}. If this page
+     * The method to read next page from sas7bdat file and put it into {@link SasFileParserExternal#cachedPage}. If this page
      * has {@link SasFileConstants#PAGE_META_TYPE} type method process it's subheaders. Method skips page with type
      * other than {@link SasFileConstants#PAGE_META_TYPE}, {@link com.epam.parso.impl.SasFileConstants#PAGE_MIX_TYPE} or
      * {@link com.epam.parso.impl.SasFileConstants#PAGE_DATA_TYPE} and reads next.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     void readNextPage() throws IOException {
         processNextPage();
@@ -956,8 +956,8 @@ public class SasFileParser {
     }
 
     /**
-     * The method to read page metadata and store it in {@link SasFileParser#currentPageType},
-     * {@link SasFileParser#currentPageBlockCount} and {@link SasFileParser#currentPageSubheadersCount}.
+     * The method to read page metadata and store it in {@link SasFileParserExternal#currentPageType},
+     * {@link SasFileParserExternal#currentPageBlockCount} and {@link SasFileParserExternal#currentPageSubheadersCount}.
      * @throws IOException
      */
     void readPageHeader() throws IOException {
@@ -979,7 +979,7 @@ public class SasFileParser {
      * The function to decompress data. Compressed data are an array of bytes with control bytes and data bytes.
      * The project documentation contains descriptions of the decompression algorithm.
      *
-     * @param offset the offset of bytes array in {@link SasFileParser#cachedPage} that contains compressed data.
+     * @param offset the offset of bytes array in {@link SasFileParserExternal#cachedPage} that contains compressed data.
      * @param length the length of bytes array that contains compressed data.
      * @return an array of bytes with decompressed data.
      */
@@ -1157,7 +1157,7 @@ public class SasFileParser {
      * @param offset the array of offsets.
      * @param length the array of lengths.
      * @return the list of bytes arrays.
-     * @throws IOException if reading from the {@link SasFileParser#sasFileStream} stream is impossible.
+     * @throws IOException if reading from the {@link SasFileParserExternal#sasFileStream} stream is impossible.
      */
     private List<byte[]> getBytesFromFile(Long[] offset, Integer[] length) throws IOException {
         List<byte[]> vars = new ArrayList<byte[]>();

--- a/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
+++ b/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
@@ -2,7 +2,9 @@ package com.github.saurfang.sas.mapred
 
 import java.io.IOException
 
-import com.ggasoftware.parso.{SasFileConstants, SasFileParser, SasFileProperties}
+import com.epam.parso.SasFileProperties
+import com.epam.parso.impl.SasFileParser
+import com.epam.parso.impl.SasFileParser.SasFileConstants
 import com.github.saurfang.sas.util.PrivateMethodExposer
 import org.apache.commons.io.input.CountingInputStream
 import org.apache.hadoop.conf.Configuration

--- a/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
+++ b/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
@@ -3,8 +3,8 @@ package com.github.saurfang.sas.mapred
 import java.io.IOException
 
 import com.epam.parso.SasFileProperties
-import com.epam.parso.impl.SasFileParser
-import com.epam.parso.impl.SasFileParser.SasFileConstants
+import com.epam.parso.impl.{SasFileParserExternal, SasFileParser}
+import com.epam.parso.impl.SasFileParserExternal.SasFileConstants
 import com.github.saurfang.sas.util.PrivateMethodExposer
 import org.apache.commons.io.input.CountingInputStream
 import org.apache.hadoop.conf.Configuration
@@ -26,7 +26,7 @@ class SasRecordReader() extends RecordReader[NullWritable, Array[Object]] {
   private var splitEnd: Long = 0L
   private var fileInputStream: FSDataInputStream = null
   private var countingInputStream: CountingInputStream = null
-  private var sasFileReader: SasFileParser = null
+  private var sasFileReader: SasFileParserExternal = null
   private var sasFileReaderPrivateExposer: PrivateMethodExposer = null
   private var recordCount: Int = 0
   private var lastPageBlockCounter: Int = 0
@@ -83,7 +83,7 @@ class SasRecordReader() extends RecordReader[NullWritable, Array[Object]] {
     fileInputStream = fs.open(file)
     countingInputStream = new CountingInputStream(fileInputStream)
     // open SAS file reader to read meta data
-    sasFileReader = new SasFileParser.ExternalBuilder().sasFileStream(countingInputStream).build() // new SasFileReader(countingInputStream)
+    sasFileReader = new SasFileParserExternal.ExternalBuilder().sasFileStream(countingInputStream).build() // new SasFileReader(countingInputStream)
     sasFileReaderPrivateExposer = PrivateMethodExposer(sasFileReader)
 
     log.info(sasFileProperties.toString)

--- a/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
+++ b/src/main/scala/com/github/saurfang/sas/mapred/SasRecordReader.scala
@@ -83,7 +83,7 @@ class SasRecordReader() extends RecordReader[NullWritable, Array[Object]] {
     fileInputStream = fs.open(file)
     countingInputStream = new CountingInputStream(fileInputStream)
     // open SAS file reader to read meta data
-    sasFileReader = new SasFileParser.Builder().sasFileStream(countingInputStream).build() // new SasFileReader(countingInputStream)
+    sasFileReader = new SasFileParser.ExternalBuilder().sasFileStream(countingInputStream).build() // new SasFileReader(countingInputStream)
     sasFileReaderPrivateExposer = PrivateMethodExposer(sasFileReader)
 
     log.info(sasFileProperties.toString)

--- a/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
+++ b/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.TimeZone
 
 import com.epam.parso.SasFileReader
-import com.epam.parso.impl.SasFileParser.SasFileConstants
+import com.epam.parso.impl.SasFileParserExternal.SasFileConstants
 import com.epam.parso.impl.SasFileReaderImpl
 import com.github.saurfang.sas.mapred.SasInputFormat
 import org.apache.hadoop.fs.Path

--- a/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
+++ b/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
@@ -3,7 +3,8 @@ package com.github.saurfang.sas.spark
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
-import com.ggasoftware.parso.{SasFileConstants, SasFileReader}
+import com.epam.parso.SasFileReader
+import com.epam.parso.impl.SasFileParser.SasFileConstants
 import com.github.saurfang.sas.mapred.SasInputFormat
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable

--- a/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
+++ b/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
@@ -5,6 +5,7 @@ import java.util.TimeZone
 
 import com.epam.parso.SasFileReader
 import com.epam.parso.impl.SasFileParser.SasFileConstants
+import com.epam.parso.impl.SasFileReaderImpl
 import com.github.saurfang.sas.mapred.SasInputFormat
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
@@ -96,7 +97,7 @@ case class SasRelation protected[spark](
       val path = new Path(location)
       val fs = path.getFileSystem(conf)
       val inputStream = fs.open(path)
-      val sasFileReader = new SasFileReader(inputStream)
+      val sasFileReader = new SasFileReaderImpl(inputStream)
       import scala.collection.JavaConversions._
       val schemaFields = sasFileReader.getColumns.map { column =>
         val columnType =

--- a/src/main/scala/com/github/saurfang/sas/util/PrivateMethodExposer.scala
+++ b/src/main/scala/com/github/saurfang/sas/util/PrivateMethodExposer.scala
@@ -14,7 +14,7 @@ class PrivateMethodCaller(x: AnyRef, methodName: String) {
 
 /**
  *
- * Use this to invoke private methods in [[com.ggasoftware.parso.SasFileParser]] so we don't need to modify it
+ * Use this to invoke private methods in [[com.epam.parso.impl.SasFileParser]] so we don't need to modify it
  * Credits to https://gist.github.com/jorgeortiz85/908035
  * Usage:
  *  p(instance)('privateMethod)(arg1, arg2, arg3)

--- a/src/main/scala/com/github/saurfang/sas/util/PrivateMethodExposer.scala
+++ b/src/main/scala/com/github/saurfang/sas/util/PrivateMethodExposer.scala
@@ -1,5 +1,7 @@
 package com.github.saurfang.sas.util
 
+import com.epam.parso.impl.{SasFileParserExternal}
+
 class PrivateMethodCaller(x: AnyRef, methodName: String) {
   def apply(_args: Any*): Any = {
     val args = _args.map(_.asInstanceOf[AnyRef])
@@ -14,7 +16,7 @@ class PrivateMethodCaller(x: AnyRef, methodName: String) {
 
 /**
  *
- * Use this to invoke private methods in [[com.epam.parso.impl.SasFileParser]] so we don't need to modify it
+ * Use this to invoke private methods in [[SasFileParserExternal]] so we don't need to modify it
  * Credits to https://gist.github.com/jorgeortiz85/908035
  * Usage:
  *  p(instance)('privateMethod)(arg1, arg2, arg3)

--- a/src/test/scala/com/github/saurfang/sas/SasRelationSpec.scala
+++ b/src/test/scala/com/github/saurfang/sas/SasRelationSpec.scala
@@ -1,9 +1,9 @@
 package com.github.saurfang.sas
 
-import com.ggasoftware.parso.SasFileConstants
+import com.epam.parso.impl.SasFileParser.SasFileConstants
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.sql.{SQLContext, SaveMode}
-import org.apache.spark.{SharedSparkContext}
+import org.apache.spark.SharedSparkContext
 import org.scalactic.TolerantNumerics
 import org.scalatest._
 import org.apache.log4j.LogManager

--- a/src/test/scala/com/github/saurfang/sas/SasRelationSpec.scala
+++ b/src/test/scala/com/github/saurfang/sas/SasRelationSpec.scala
@@ -1,6 +1,6 @@
 package com.github.saurfang.sas
 
-import com.epam.parso.impl.SasFileParser.SasFileConstants
+import com.epam.parso.impl.SasFileParserExternal.SasFileConstants
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.sql.{SQLContext, SaveMode}
 import org.apache.spark.SharedSparkContext


### PR DESCRIPTION
updated parso version. 
There is a test "SASRelation" should "support export datetime to csv/parquet"
failed even for the master branch under saufang/spark-sas7dat