### PR TITLE
Add support for reading SAS column label metadata.

### DIFF
--- a/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
+++ b/src/main/scala/com/github/saurfang/sas/spark/SasRelation.scala
@@ -128,7 +128,7 @@ case class SasRelation protected[spark](
           } else {
             StringType
           }
-        StructField(column.getName, columnType, nullable = true)
+        StructField(column.getName, columnType, nullable = true).withComment(column.getLabel)
       }
       inputStream.close()
       StructType(schemaFields)


### PR DESCRIPTION
This is a minor change which allows the reader to correctly extract the SAS column labels as column comments.

This is useful for parquet-files/hive-tables, as spark transparently passes through this metadata.