### PR TITLE
support spark 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,40 @@
 language: scala
-scala:
-  - 2.10.7
-  - 2.11.12
-jdk:
-  - oraclejdk9
-  - openjdk8
-sudo: false
-script:
-  - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test test
-  - sbt -jvm-opts travis/jvmopts.test scalastyle
 
-# These directories are cached to S3 at the end of the build
+sudo: false
+
 cache:
+  # these directories are cached to S3 at the end of the build
   directories:
-    - $HOME/.ivy2/cache
     - $HOME/.sbt
+    - $HOME/.ivy2/cache
+
+matrix:
+  include:
+    - name: Spark 2.4.6
+      env: SPARK_VERSION=2.4.6
+      scala:
+        - 2.11.12
+      jdk:
+        - openjdk8
+    - name: Spark 3.0.0 (Java 8)
+      env: SPARK_VERSION=3.0.0
+      scala:
+        - 2.12.11
+      jdk:
+        - openjdk8
+    - name: Spark 3.0.0 (Java 11)
+      env: SPARK_VERSION=3.0.0
+      scala:
+        - 2.12.11
+      jdk:
+        - openjdk11
+
+script:
+  - sbt -jvm-opts travis/jvmopts.test    ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION scalastyle
+  - sbt -jvm-opts travis/jvmopts.test    ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION test
+  - sbt -jvm-opts travis/jvmopts.compile ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION assembly
 
 before_cache:
-  # Cleanup the cached directories to avoid unnecessary cache updates
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt        -name "*.lock"               -print -delete
+  # cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt  -name "*.lock"               -print -delete

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A library for reading SAS data (.sas7bdat) with [Spark](http://spark.apache.org/
 
 ## Requirements:
 
-- [Spark 1.4+ or 2.0+](https://spark.apache.org/downloads.html)
-- [Parso 2.0.10](https://mvnrepository.com/artifact/com.epam/parso/2.0.10)
+- [Spark 2.0+ or 3.0+](https://spark.apache.org/downloads.html)
+- [Parso 2.0.11](https://mvnrepository.com/artifact/com.epam/parso/2.0.11)
 
 ## Download:
 
@@ -103,9 +103,9 @@ write.df(df, path = "newcars.csv", source = "csv", header = TRUE)
 SAS data can be queried in pure SQL by registering the data as a (temporary) table.
 
 ```sql
-CREATE TEMPORARY TABLE cars
+CREATE TEMPORARY VIEW cars
 USING com.github.saurfang.sas.spark
-OPTIONS (path "cars.sas7bdat")
+OPTIONS (path="cars.sas7bdat")
 ```
 
 ### SAS Export Runner
@@ -123,7 +123,7 @@ cluster, you can always run it in local mode and take advantage of multi-core.
 ### Spark Shell
 
 ```bash
-spark-shell --master local[4] --packages saurfang:spark-sas7bdat:2.1.0-s_2.11
+spark-shell --master local[4] --packages saurfang:spark-sas7bdat:3.0.0-s_2.12
 ```
 
 ## Caveats

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,35 @@
-name := "spark-sas7bdat"
-version := "2.1.1"
-organization := "com.github.saurfang"
+val sparkVersion = sys.props.getOrElse("spark.version", "3.0.0")
+val defaultScalaVersion = sparkVersion match {
+  case s if s.startsWith("3.") => "2.12.11"
+  case s if s.startsWith("2.") => "2.12.11"
+  case _ => throw new IllegalArgumentException(s"Unsupported spark.version: $sparkVersion")
+}
 
-scalaVersion := "2.11.12"
-crossScalaVersions := Seq("2.10.7", "2.11.12")
+name := "spark-sas7bdat"
+version := "3.0.0"
+organization := "com.github.saurfang"
+licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+
+scalaVersion := sys.props.getOrElse("scala.version", defaultScalaVersion)
+crossScalaVersions := Seq("2.11.12", "2.12.11")
 
 scalacOptions ++= Seq("-target:jvm-1.8")
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-libraryDependencies ++= Seq(
-  "com.epam" % "parso" % "2.0.10",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-  "org.apache.logging.log4j" %% "log4j-api-scala" % "2.7"
-)
-
-//sbt-spark-package
-spName := "saurfang/spark-sas7bdat"
-sparkVersion := "2.2.0"
-sparkComponents += "sql"
-spAppendScalaVersion := true
 credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
-licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
+
+libraryDependencies ++= Seq(
+  // main
+  "com.epam" % "parso" % "2.0.11",
+  "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
+
+  // spark
+  "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
+
+  // testing
+  "org.scalatest" %% "scalatest" % "3.1.2" % "test",
+)
 
 //include provided dependencies in sbt run task
 run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in(Compile, run), runner in(Compile, run))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
+resolvers += "Sonatype" at "https://oss.sonatype.org/content/repositories/releases/org/scalastyle"
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")

--- a/src/test/scala/com/github/saurfang/sas/spark/DefaultSourceSuite.scala
+++ b/src/test/scala/com/github/saurfang/sas/spark/DefaultSourceSuite.scala
@@ -35,9 +35,9 @@ class DefaultSourceSuite extends FunSuite with Matchers with SharedSparkContext 
     // Read using pure SQL statements.
     sqlContext.sql(
       s"""
-         |CREATE TEMPORARY TABLE datetimeTable
+         |CREATE TEMPORARY VIEW datetimeTable
          |USING com.github.saurfang.sas.spark
-         |OPTIONS (path "$sasDatetimePath")
+         |OPTIONS (path="$sasDatetimePath")
       """.stripMargin)
     val sqlDF = sqlContext.sql("SELECT * FROM datetimeTable")
 


### PR DESCRIPTION
This PR implements support for Spark 3.0 (Scala 2.12)

To get this merged we will need to:
* confirm if we have broken support for older versions of Spark, and if so, update the docs.
* validate that this works in real deployments, not just unit tests